### PR TITLE
Update component.py

### DIFF
--- a/asphalt/core/component.py
+++ b/asphalt/core/component.py
@@ -88,7 +88,7 @@ class ContainerComponent(Component):
             raise TypeError('component_alias must be a nonempty string')
         if alias in self.child_components:
             raise ValueError('there is already a child component named "{}"'.format(alias))
-        
+
         config['type'] = type or alias
 
         # Allow the external configuration to override the constructor arguments

--- a/asphalt/core/component.py
+++ b/asphalt/core/component.py
@@ -88,12 +88,14 @@ class ContainerComponent(Component):
             raise TypeError('component_alias must be a nonempty string')
         if alias in self.child_components:
             raise ValueError('there is already a child component named "{}"'.format(alias))
+        
+        config['type'] = type or alias
 
         # Allow the external configuration to override the constructor arguments
         override_config = self.component_configs.get(alias) or {}
         config = merge_config(config, override_config)
 
-        component = component_types.create_object(type or alias, **config)
+        component = component_types.create_object(**config)
         self.child_components[alias] = component
 
     async def start(self, ctx: Context):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -27,6 +27,10 @@ class TestContainerComponent:
     def container(self):
         return ContainerComponent({'dummy': {'a': 1, 'c': 3}})
 
+    @pytest.fixture
+    def container_with_type(self):
+        return ContainerComponent({'dummy': {'type': DummyComponent}})
+
     def test_add_component(self, container):
         """
         Test that add_component works with an without an entry point and that external
@@ -39,6 +43,18 @@ class TestContainerComponent:
         component = container.child_components['dummy']
         assert isinstance(component, DummyComponent)
         assert component.kwargs == {'a': 1, 'b': 2, 'c': 3}
+
+    def test_add_component_with_type(self, container_with_type):
+        """
+        Test that add_component works with a `type` specified in a
+        configuration overriddes directly supplied configuration values.
+
+        """
+        container_with_type.add_component('dummy')
+
+        assert len(container_with_type.child_components) == 1
+        component = container_with_type.child_components['dummy']
+        assert isinstance(component, DummyComponent)
 
     @pytest.mark.parametrize('alias, cls, exc_cls, message', [
         ('', None, TypeError, 'component_alias must be a nonempty string'),

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -27,10 +27,6 @@ class TestContainerComponent:
     def container(self):
         return ContainerComponent({'dummy': {'a': 1, 'c': 3}})
 
-    @pytest.fixture
-    def container_with_type(self):
-        return ContainerComponent({'dummy': {'type': DummyComponent}})
-
     def test_add_component(self, container):
         """
         Test that add_component works with an without an entry point and that external
@@ -44,16 +40,16 @@ class TestContainerComponent:
         assert isinstance(component, DummyComponent)
         assert component.kwargs == {'a': 1, 'b': 2, 'c': 3}
 
-    def test_add_component_with_type(self, container_with_type):
+    def test_add_component_with_type(self):
         """
         Test that add_component works with a `type` specified in a
         configuration overriddes directly supplied configuration values.
 
         """
-        container_with_type.add_component('dummy')
-
-        assert len(container_with_type.child_components) == 1
-        component = container_with_type.child_components['dummy']
+        container = ContainerComponent({'dummy': {'type': DummyComponent}})
+        container.add_component('dummy')
+        assert len(container.child_components) == 1
+        component = container.child_components['dummy']
         assert isinstance(component, DummyComponent)
 
     @pytest.mark.parametrize('alias, cls, exc_cls, message', [


### PR DESCRIPTION
If a `type` is specified in a component definition, it should be preferred. This fixes the bug where a component cannot specify it's type in a config definition (as two `type` arguments would be passed to `component_types.create_object`.