### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     python_requires='>= 3.5.2',
     install_requires=[
         'setuptools',  # this is here to tell downstream packagers that it needs pkg_resources
-        'ruamel.yaml >= 0.12',
+        'ruamel.yaml >= 0.12, < 0.15',
         'typeguard ~= 2.0',
         'async-generator ~= 1.4',
         'asyncio_extras ~= 1.3',


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.