### PR TITLE
Add link to documentation from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ their services as *resources* in a shared *context*. Components can build on res
 each other, making it possible to create components that offer highly sophisticated functionality
 with relatively little effort.
 
+Full documentation: https://asphalt.readthedocs.io/en/latest/
+
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 .. _uvloop: https://github.com/MagicStack/uvloop
 .. _tokio: https://github.com/PyO3/tokio

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ their services as *resources* in a shared *context*. Components can build on res
 each other, making it possible to create components that offer highly sophisticated functionality
 with relatively little effort.
 
-Full documentation: https://asphalt.readthedocs.io/en/latest/
+Full documentation: https://asphalt.readthedocs.io/
 
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 .. _uvloop: https://github.com/MagicStack/uvloop


### PR DESCRIPTION
Had to go digging a little bit to find the actual documentation beyond the readme. Include a link in the readme to make it easier to find.