### PR TITLE
Make configuration files optional

### DIFF
--- a/docs/userguide/deployment.rst
+++ b/docs/userguide/deployment.rst
@@ -17,15 +17,15 @@ Running the launcher is very straightfoward:
 
 .. code-block:: bash
 
-    asphalt run yourconfig.yaml [your-overrides.yml...] [--set path.to.key=val]
+    asphalt run [yourconfig.yaml your-overrides.yml...] [--set path.to.key=val]
 
 Or alternatively:
 
-    python -m asphalt run yourconfig.yaml [your-overrides.yml...] [--set path.to.key=val]
+    python -m asphalt [run yourconfig.yaml your-overrides.yml...] [--set path.to.key=val]
 
 What this will do is:
 
-#. read all the given configuration files, starting from ``yourconfig.yaml``
+#. read all the given configuration files, if any, starting from ``yourconfig.yaml``
 #. read the command line configuration options passed with ``--set``, if any
 #. merge the configuration files' contents and the command line configuration options into a single configuration dictionary using
    :func:`~asphalt.core.utils.merge_config`.

--- a/src/asphalt/core/cli.py
+++ b/src/asphalt/core/cli.py
@@ -34,7 +34,9 @@ def main() -> None:
     pass  # pragma: no cover
 
 
-@main.command(help="Read configuration files, pass configuration options, and start the application.")
+@main.command(
+    help="Read configuration files, pass configuration options, and start the application."
+)
 @click.argument("configfile", type=click.File(), nargs=-1)
 @click.option(
     "--unsafe",

--- a/src/asphalt/core/cli.py
+++ b/src/asphalt/core/cli.py
@@ -34,8 +34,8 @@ def main() -> None:
     pass  # pragma: no cover
 
 
-@main.command(help="Read one or more configuration files and start the application.")
-@click.argument("configfile", type=click.File(), nargs=-1, required=True)
+@main.command(help="Read configuration files, pass configuration options, and start the application.")
+@click.argument("configfile", type=click.File(), nargs=-1)
 @click.option(
     "--unsafe",
     is_flag=True,


### PR DESCRIPTION
Now that we can [pass configuration at the command line](https://github.com/asphalt-framework/asphalt/pull/50), I guess that configuration files become optional.