### PR TITLE
Keep a reference to tasks

### DIFF
--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -42,7 +42,7 @@ Create a ``tests`` directory at the root of the project directory and create a m
                 client = ClientComponent("Hello!")
                 await client.start(ctx)
 
-        event_loop.create_task(run())
+        task = event_loop.create_task(run())
         with pytest.raises(SystemExit) as exc:
             event_loop.run_forever()
 

--- a/examples/tutorial1/tests/test_client_server.py
+++ b/examples/tutorial1/tests/test_client_server.py
@@ -21,7 +21,7 @@ def test_client_and_server(
             client = ClientComponent("Hello!")
             await client.start(ctx)
 
-    event_loop.create_task(run())
+    task = event_loop.create_task(run())  # noqa: F841
     with pytest.raises(SystemExit) as exc:
         event_loop.run_forever()
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -94,7 +94,9 @@ class TestSignal:
         assert events[0].kwargs == {"a": 1, "b": 2}
 
     @pytest.mark.asyncio
-    async def test_dispatch_event_coroutine_complete(self, source: DummySource, capfd) -> None:
+    async def test_dispatch_event_coroutine_complete(
+        self, source: DummySource, capfd
+    ) -> None:
         """Test that a coroutine function listening to an event runs until complete."""
 
         async def callback(event: Event) -> None:


### PR DESCRIPTION
Tasks may disappear while executing because of garbage collection. See [the documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):

![image](https://user-images.githubusercontent.com/4711805/225574587-22191c03-d59d-4697-8db5-bd78862ab927.png)