### PR TITLE
Add --help-all CLI

### DIFF
--- a/src/asphalt/core/cli.py
+++ b/src/asphalt/core/cli.py
@@ -10,7 +10,8 @@ import click
 from ruamel.yaml import YAML, ScalarNode
 from ruamel.yaml.loader import Loader
 
-from .runner import policies, run_application
+from .component import component_set_help_all
+from .runner import policies, run_application, runner_set_help_all
 from .utils import merge_config, qualified_name
 
 
@@ -63,13 +64,23 @@ def main() -> None:
     type=str,
     help="set configuration",
 )
+@click.option(
+    "--help-all",
+    is_flag=True,
+    default=False,
+    help="show all components' configuration parameters and exit",
+)
 def run(
     configfile,
     unsafe: bool,
     loop: str | None,
     service: str | None,
     set_: list[str],
+    help_all: bool,
 ) -> None:
+    component_set_help_all(help_all)
+    runner_set_help_all(help_all)
+
     yaml = YAML(typ="unsafe" if unsafe else "safe")
     yaml.constructor.add_constructor("!Env", env_constructor)
     yaml.constructor.add_constructor("!TextFile", text_file_constructor)

--- a/src/asphalt/core/runner.py
+++ b/src/asphalt/core/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ("run_application",)
 
 import asyncio
+import inspect
 import signal
 import sys
 from asyncio.events import AbstractEventLoop
@@ -16,6 +17,13 @@ from .context import Context, _current_context
 from .utils import PluginContainer, qualified_name
 
 policies = PluginContainer("asphalt.core.event_loop_policies")
+
+help_all = False
+
+
+def runner_set_help_all(val):
+    global help_all
+    help_all = val
 
 
 def sigterm_handler(logger: Logger, event_loop: AbstractEventLoop) -> None:
@@ -94,6 +102,10 @@ def run_application(
         # Instantiate the root component if a dict was given
         if isinstance(component, dict):
             component = cast(Component, component_types.create_object(**component))
+
+        if help_all:
+            signature = inspect.signature(component.__init__)  # type: ignore[misc]
+            print(component.__class__.__name__, signature)
 
         logger.info("Starting application")
         context = Context()


### PR DESCRIPTION
Closes #71

@agronholm what do you think about doing something like that, where the configuration is printed as a side effect of running the application? I guess there is no way to "inspect" the application structure and gather all components' configuration without actually creating the resources, right?
This will show something like:
```console
$ my_app --help-all
Container0 (components: 'dict[str, dict[str, Any] | None] | None' = None) -> 'None'
Container0.container1 (components: 'dict[str, dict[str, Any] | None] | None' = None) -> 'None'
Container0.container2 (components: 'dict[str, dict[str, Any] | None] | None' = None) -> 'None'
Container0.container1.dummy (dummyval1=None, dummyval2=None)
Container0.container2.dummy (dummyval1=None, dummyval2=None)
```