### PR TITLE
Don't raise exception on SIGTERM or SIGINT

### DIFF
--- a/src/asphalt/core/_runner.py
+++ b/src/asphalt/core/_runner.py
@@ -14,7 +14,6 @@ from anyio import (
     create_task_group,
     fail_after,
     get_cancelled_exc_class,
-    sleep,
     to_thread,
 )
 from anyio.abc import TaskStatus
@@ -118,7 +117,9 @@ async def run_application(
             event = Event()
             if platform.system() != "Windows":
                 root_tg = await exit_stack.enter_async_context(create_task_group())
-                await root_tg.start(handle_signals, event, name="Asphalt signal handler")
+                await root_tg.start(
+                    handle_signals, event, name="Asphalt signal handler"
+                )
                 exit_stack.callback(root_tg.cancel_scope.cancel)
 
             ctx = await exit_stack.enter_async_context(Context())

--- a/src/asphalt/core/_runner.py
+++ b/src/asphalt/core/_runner.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 
 import anyio
 from anyio import (
+    Event,
     create_task_group,
     fail_after,
     get_cancelled_exc_class,
@@ -27,7 +28,7 @@ if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
 
-async def handle_signals(*, task_status: TaskStatus) -> None:
+async def handle_signals(event, *, task_status: TaskStatus) -> None:
     logger = getLogger(__name__)
     with anyio.open_signal_receiver(signal.SIGTERM, signal.SIGINT) as signals:
         task_status.started()
@@ -37,7 +38,7 @@ async def handle_signals(*, task_status: TaskStatus) -> None:
                 "Received signal (%s) – terminating application",
                 signal_name.split(":", 1)[0],  # macOS has ": <signum>" after the name
             )
-            raise ApplicationExit
+            event.set()
 
 
 def handle_application_exit(excgrp: ExceptionGroup) -> None:
@@ -114,9 +115,10 @@ async def run_application(
         async with AsyncExitStack() as exit_stack:
             handlers = {ApplicationExit: handle_application_exit}
             exit_stack.enter_context(catch(handlers))  # type: ignore[arg-type]
+            event = Event()
             if platform.system() != "Windows":
                 root_tg = await exit_stack.enter_async_context(create_task_group())
-                await root_tg.start(handle_signals, name="Asphalt signal handler")
+                await root_tg.start(handle_signals, event, name="Asphalt signal handler")
                 exit_stack.callback(root_tg.cancel_scope.cancel)
 
             ctx = await exit_stack.enter_async_context(Context())
@@ -134,6 +136,7 @@ async def run_application(
                 raise
 
             logger.info("Application started")
-            await sleep(float("inf"))
+
+            await event.wait()
     finally:
         logger.info("Application stopped")


### PR DESCRIPTION
With this example, one cannot exit the application with CTRL-C:
```py
from anyio import run
from asphalt.core import Component, ContainerComponent, context_teardown, run_application
from fastapi import FastAPI
from uvicorn import Config, Server

class ServerComponent(Component):
    @context_teardown
    async def start(self, ctx):
        app = FastAPI()
        config = Config(app=app)
        server = Server(config)
        server.install_signal_handlers = lambda: None
        await ctx.start_background_task(server.serve, "uvicorn", cancel_on_exit=False)
        yield
        server.should_exit = True

class Component0(ContainerComponent):
    async def start(self, ctx):
        self.add_component("server", ServerComponent)
        await super().start(ctx)

run(run_application, Component0())
```