### PR TITLE
Removed the context parameter from all callbacks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,6 @@ Concurrency
 -----------
 
 .. autofunction:: start_background_task
-.. autofunction:: start_service_task
 
 Contexts and resources
 ----------------------
@@ -24,6 +23,8 @@ Contexts and resources
 .. autofunction:: current_context
 .. autofunction:: context_teardown
 .. autofunction:: add_resource
+.. autofunction:: add_resource_factory
+.. autofunction:: add_teardown_callback
 .. autofunction:: get_resource
 .. autofunction:: require_resource
 .. autofunction:: inject
@@ -35,7 +36,7 @@ Contexts and resources
 Events
 ------
 
-.. autoclass:: ResourceEvent
+.. autoclass:: Event
 .. autoclass:: Signal
 .. autofunction:: stream_events
 .. autofunction:: wait_event
@@ -52,3 +53,4 @@ Utilities
 .. autofunction:: callable_name
 .. autofunction:: merge_config
 .. autofunction:: qualified_name
+.. autofunction:: resolve_reference

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,8 +23,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - **BACKWARD INCOMPATIBLE** Dropped the deprecated ``parent`` argument to ``Context``
 - **BACKWARD INCOMPATIBLE** Dropped the deprecated ``Dependency()`` marker
 - **BACKWARD INCOMPATIBLE** Dropped support for context attributes
-- **BACKWARD INCOMPATIBLE** Dropped the ``ctx`` parameter from
-  ``CLIApplicationComponent.run()``
+- **BACKWARD INCOMPATIBLE** Dropped the ``ctx`` parameter from all callbacks, including:
+
+  * ``Component.start()``
+  * ``CLIApplicationComponent.run()``
+  * resource factory callbacks
 - **BACKWARD INCOMPATIBLE** Refactored the event system:
 
   * The ``connect()``, ``disconnect()`` and ``dispatch_raw()`` methods were removed

--- a/examples/tutorial1/echo/server.py
+++ b/examples/tutorial1/echo/server.py
@@ -8,7 +8,6 @@ from anyio.abc import SocketStream
 
 from asphalt.core import (
     Component,
-    Context,
     context_teardown,
     run_application,
     start_background_task,
@@ -23,7 +22,7 @@ async def handle(stream: SocketStream) -> None:
 
 class ServerComponent(Component):
     @context_teardown
-    async def start(self, ctx: Context) -> AsyncGenerator[None, Exception | None]:
+    async def start(self) -> AsyncGenerator[None, Exception | None]:
         async with await anyio.create_tcp_listener(
             local_host="localhost", local_port=64100
         ) as listener:

--- a/examples/tutorial1/tests/test_client_server.py
+++ b/examples/tutorial1/tests/test_client_server.py
@@ -2,7 +2,7 @@
 import pytest
 
 from asphalt.core import Context
-from _pytest.capture import CaptureFixture
+from pytest import CaptureFixture
 
 from echo.client import ClientComponent
 from echo.server import ServerComponent
@@ -11,12 +11,12 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_client_and_server(capsys: CaptureFixture[str]) -> None:
-    async with Context() as ctx:
+    async with Context():
         server = ServerComponent()
-        await server.start(ctx)
+        await server.start()
 
         client = ClientComponent("Hello!")
-        await client.start(ctx)
+        await client.start()
 
     # Grab the captured output of sys.stdout and sys.stderr from the capsys fixture
     out, err = capsys.readouterr()

--- a/examples/tutorial2/webnotifier/app.py
+++ b/examples/tutorial2/webnotifier/app.py
@@ -3,7 +3,7 @@
 import logging
 from difflib import HtmlDiff
 
-from asphalt.core import CLIApplicationComponent, Context, inject, resource
+from asphalt.core import CLIApplicationComponent, inject, resource
 from asphalt.mailer.api import Mailer
 
 from webnotifier.detector import ChangeDetectorComponent, Detector
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 class ApplicationComponent(CLIApplicationComponent):
-    async def start(self, ctx: Context) -> None:
+    async def start(self) -> None:
         self.add_component("detector", ChangeDetectorComponent)
         self.add_component("mailer", backend="smtp")
-        await super().start(ctx)
+        await super().start()
 
     @inject
     async def run(

--- a/examples/tutorial2/webnotifier/detector.py
+++ b/examples/tutorial2/webnotifier/detector.py
@@ -12,11 +12,11 @@ import anyio
 import httpx
 from asphalt.core import (
     Component,
-    Context,
     Event,
     Signal,
     context_teardown,
     start_background_task,
+    add_resource,
 )
 
 logger = logging.getLogger(__name__)
@@ -64,9 +64,9 @@ class ChangeDetectorComponent(Component):
         self.delay = delay
 
     @context_teardown
-    async def start(self, ctx: Context) -> AsyncGenerator[None, Exception | None]:
+    async def start(self) -> AsyncGenerator[None, Exception | None]:
         detector = Detector(self.url, self.delay)
-        await ctx.add_resource(detector)
+        await add_resource(detector)
         await start_background_task(detector.run, "Web page change detector")
         logging.info(
             'Started web page change detector for url "%s" with a delay of %d seconds',

--- a/src/asphalt/core/__init__.py
+++ b/src/asphalt/core/__init__.py
@@ -1,69 +1,37 @@
-__all__ = (
-    "ApplicationExit",
-    "CLIApplicationComponent",
-    "Component",
-    "ContainerComponent",
-    "start_background_task",
-    "Context",
-    "GeneratedResource",
-    "ResourceConflict",
-    "ResourceEvent",
-    "ResourceNotFound",
-    "add_resource",
-    "context_teardown",
-    "current_context",
-    "get_resource",
-    "get_resources",
-    "require_resource",
-    "NoCurrentContext",
-    "inject",
-    "resource",
-    "Event",
-    "Signal",
-    "stream_events",
-    "wait_event",
-    "run_application",
-    "PluginContainer",
-    "callable_name",
-    "merge_config",
-    "qualified_name",
-    "resolve_reference",
-)
-
 from typing import Any
 
-from ._component import (
-    CLIApplicationComponent,
-    Component,
-    ContainerComponent,
-)
-from ._context import (
-    Context,
-    GeneratedResource,
-    NoCurrentContext,
-    ResourceConflict,
-    ResourceEvent,
-    ResourceNotFound,
-    add_resource,
-    context_teardown,
-    current_context,
-    get_resource,
-    get_resources,
-    inject,
-    require_resource,
-    resource,
-    start_background_task,
-)
-from ._event import Event, Signal, stream_events, wait_event
-from ._exceptions import ApplicationExit
-from ._runner import run_application
-from ._utils import (
-    PluginContainer,
-    callable_name,
-    merge_config,
-    qualified_name,
-    resolve_reference,
-)
+from ._component import CLIApplicationComponent as CLIApplicationComponent
+from ._component import Component as Component
+from ._component import ContainerComponent as ContainerComponent
+from ._context import Context as Context
+from ._context import GeneratedResource as GeneratedResource
+from ._context import NoCurrentContext as NoCurrentContext
+from ._context import ResourceConflict as ResourceConflict
+from ._context import ResourceEvent as ResourceEvent
+from ._context import ResourceNotFound as ResourceNotFound
+from ._context import add_resource as add_resource
+from ._context import add_resource_factory as add_resource_factory
+from ._context import add_teardown_callback as add_teardown_callback
+from ._context import context_teardown as context_teardown
+from ._context import current_context as current_context
+from ._context import get_resource as get_resource
+from ._context import get_resources as get_resources
+from ._context import inject as inject
+from ._context import request_resource as request_resource
+from ._context import require_resource as require_resource
+from ._context import resource as resource
+from ._context import start_background_task as start_background_task
+from ._event import Event as Event
+from ._event import Signal as Signal
+from ._event import stream_events as stream_events
+from ._event import wait_event as wait_event
+from ._exceptions import ApplicationExit as ApplicationExit
+from ._runner import run_application as run_application
+from ._utils import PluginContainer as PluginContainer
+from ._utils import callable_name as callable_name
+from ._utils import merge_config as merge_config
+from ._utils import qualified_name as qualified_name
+from ._utils import resolve_reference as resolve_reference
 
 # Re-export imports so they look like they live directly in this package
 key: str

--- a/src/asphalt/core/_runner.py
+++ b/src/asphalt/core/_runner.py
@@ -122,10 +122,10 @@ async def run_application(
                 )
                 exit_stack.callback(root_tg.cancel_scope.cancel)
 
-            ctx = await exit_stack.enter_async_context(Context())
+            await exit_stack.enter_async_context(Context())
             try:
                 with fail_after(start_timeout):
-                    await component.start(ctx)
+                    await component.start()
             except TimeoutError:
                 logger.error("Timeout waiting for the root component to start")
                 raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
 
-from asphalt.core import Component, Context, _cli
+from asphalt.core import Component, _cli
 
 pytestmark = pytest.mark.anyio()
 
@@ -17,7 +17,7 @@ class DummyComponent(Component):
         self.dummyval1 = dummyval1
         self.dummyval2 = dummyval2
 
-    async def start(self, ctx: Context) -> None:
+    async def start(self) -> None:
         pass
 
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import NoReturn
+from typing import Any, NoReturn
 from unittest.mock import Mock
 
 import anyio
@@ -29,11 +29,11 @@ else:
 
 
 class DummyComponent(Component):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         self.kwargs = kwargs
         self.started = False
 
-    async def start(self, ctx):
+    async def start(self) -> None:
         await anyio.sleep(0.1)
         self.started = True
 
@@ -111,8 +111,8 @@ class TestContainerComponent:
         assert str(exc.value) == 'there is already a child component named "dummy"'
 
     async def test_start(self, container) -> None:
-        async with Context() as ctx:
-            await container.start(ctx)
+        async with Context():
+            await container.start()
 
         assert container.child_components["dummy"].started
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,7 +15,8 @@ from asphalt.core import (
     ApplicationExit,
     CLIApplicationComponent,
     Component,
-    Context,
+    add_teardown_callback,
+    request_resource,
     run_application,
     start_background_task,
 )
@@ -47,8 +48,8 @@ class ShutdownComponent(Component):
         elif self.method == "exception":
             raise RuntimeError("this should crash the application")
 
-    async def start(self, ctx: Context) -> None:
-        ctx.add_teardown_callback(self.teardown_callback, pass_exception=True)
+    async def start(self) -> None:
+        add_teardown_callback(self.teardown_callback, pass_exception=True)
         if self.method == "timeout":
             await anyio.sleep(1)
         else:
@@ -61,7 +62,7 @@ class CrashComponent(Component):
     def __init__(self, method: str = "exit"):
         self.method = method
 
-    async def start(self, ctx: Context) -> None:
+    async def start(self) -> None:
         if self.method == "keyboard":
             raise KeyboardInterrupt
         elif self.method == "sigterm":
@@ -198,9 +199,9 @@ async def test_start_timeout(caplog):
     """
 
     class StallingComponent(Component):
-        async def start(self, ctx: Context) -> None:
+        async def start(self) -> None:
             # Wait forever for a non-existent resource
-            await ctx.request_resource(float)
+            await request_resource(float)
 
     caplog.set_level(logging.INFO)
     component = StallingComponent()


### PR DESCRIPTION
We no longer need to pass it this way, as the context is available from  a contextvar.