### PR TITLE
Keep track of handles of all active tasks in a task factory

### DIFF
--- a/src/asphalt/core/_concurrent.py
+++ b/src/asphalt/core/_concurrent.py
@@ -55,6 +55,15 @@ class TaskHandle:
         """Wait until the task is finished."""
         await self._finished_event.wait()
 
+    def __hash__(self) -> int:
+        return hash(self._cancel_scope)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TaskHandle):
+            return self._cancel_scope is other._cancel_scope
+
+        return NotImplemented
+
 
 async def _run_background_task(
     func: Callable[..., Coroutine[Any, Any, Any]],
@@ -98,6 +107,15 @@ class TaskFactory:
     exception_handler: ExceptionHandler | None = None
     _finished_event: Event = field(init=False, default_factory=Event)
     _task_group: TaskGroup = field(init=False)
+    _tasks: set[TaskHandle] = field(init=False, default_factory=set)
+
+    def all_task_handles(self) -> set[TaskHandle]:
+        """
+        Return task handles for all the tasks currently running on the factory's task
+        group.
+
+        """
+        return self._tasks.copy()
 
     async def start_task(
         self,
@@ -127,8 +145,9 @@ class TaskFactory:
 
         """
         task_handle = TaskHandle(name=name or callable_name(func))
+        self._tasks.add(task_handle)
         task_handle.start_value = await self._task_group.start(
-            _run_background_task,
+            self._run_background_task,
             func,
             task_handle,
             self.exception_handler,
@@ -154,14 +173,31 @@ class TaskFactory:
 
         """
         task_handle = TaskHandle(name=name or callable_name(func))
+        self._tasks.add(task_handle)
         self._task_group.start_soon(
-            _run_background_task,
+            self._run_background_task,
             func,
             task_handle,
             self.exception_handler,
             name=task_handle.name,
         )
         return task_handle
+
+    async def _run_background_task(
+        self,
+        func: Callable[..., Coroutine[Any, Any, Any]],
+        task_handle: TaskHandle,
+        exception_handler: ExceptionHandler | None = None,
+        *,
+        task_status: TaskStatus[Any] = TASK_STATUS_IGNORED,
+    ) -> None:
+        __tracebackhide__ = True  # trick supported by certain debugger frameworks
+        try:
+            await _run_background_task(
+                func, task_handle, exception_handler, task_status=task_status
+            )
+        finally:
+            self._tasks.remove(task_handle)
 
     async def _run(self, *, task_status: TaskStatus[None]) -> None:
         async with create_task_group() as self._task_group:


### PR DESCRIPTION
This will allow for follow-up additions like cancelling/waiting on all the tasks.