### PR TITLE
Refactored component startup

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,6 +46,11 @@ Events
 .. autofunction:: stream_events
 .. autofunction:: wait_event
 
+Exceptions
+----------
+
+.. autoexception:: ComponentStartError
+
 Application runner
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,8 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 exclude_also = [
-    "@overload"
+    "@overload",
+    "if TYPE_CHECKING:"
 ]
 
 [tool.tox]

--- a/src/asphalt/core/__init__.py
+++ b/src/asphalt/core/__init__.py
@@ -25,6 +25,7 @@ from ._event import SignalQueueFull as SignalQueueFull
 from ._event import stream_events as stream_events
 from ._event import wait_event as wait_event
 from ._exceptions import AsyncResourceError as AsyncResourceError
+from ._exceptions import ComponentStartError as ComponentStartError
 from ._exceptions import NoCurrentContext as NoCurrentContext
 from ._exceptions import ResourceConflict as ResourceConflict
 from ._exceptions import ResourceNotFound as ResourceNotFound

--- a/src/asphalt/core/_component.py
+++ b/src/asphalt/core/_component.py
@@ -2,26 +2,50 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Coroutine, MutableMapping
-from dataclasses import dataclass, field
+from collections import defaultdict
+from collections.abc import (
+    Awaitable,
+    Coroutine,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
+from dataclasses import dataclass
 from inspect import isclass
 from traceback import StackSummary
 from types import FrameType
-from typing import Any, TypeVar, overload
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Literal,
+    TypeVar,
+    get_type_hints,
+    overload,
+)
 
 from anyio import (
-    CancelScope,
     create_task_group,
-    get_current_task,
-    get_running_tasks,
-    sleep,
+    move_on_after,
 )
 from anyio.abc import TaskStatus
 
-from ._concurrent import start_service_task
-from ._context import current_context
-from ._exceptions import NoCurrentContext
-from ._utils import PluginContainer, merge_config, qualified_name
+from ._context import (
+    Context,
+    FactoryCallback,
+    T_Resource,
+    TeardownCallback,
+    current_context,
+)
+from ._event import Event, Signal, wait_event
+from ._exceptions import ComponentStartError, NoCurrentContext, ResourceNotFound
+from ._utils import (
+    PluginContainer,
+    coalesce_exceptions,
+    format_component_name,
+    merge_config,
+    qualified_name,
+)
 
 logger = logging.getLogger("asphalt.core")
 
@@ -31,8 +55,14 @@ TComponent = TypeVar("TComponent", bound="Component")
 class Component(metaclass=ABCMeta):
     """This is the base class for all Asphalt components."""
 
+    _isolated: ClassVar[bool]
+
     _child_components: dict[str, dict[str, Any]] | None = None
     _component_started = False
+
+    def __init_subclass__(cls, *, isolated: bool = False, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._isolated = isolated
 
     def add_component(
         self, alias: str, /, type: str | type[Component] | None = None, **config: Any
@@ -131,92 +161,6 @@ class CLIApplicationComponent(Component):
 component_types = PluginContainer("asphalt.components", Component)
 
 
-def _init_component(
-    config: object,
-    path: str,
-    child_components_by_alias: dict[str, dict[str, Component]],
-) -> Component:
-    if not isinstance(config, MutableMapping):
-        raise TypeError(
-            f"{path}: config must be a mutable mapping, not {qualified_name(config)}"
-        )
-
-    # Separate the child components from the config
-    child_components_config = config.pop("components", {})
-
-    # Resolve the type to a class
-    component_type = config.pop("type")
-    component_class = component_types.resolve(component_type)
-    if not isclass(component_class) or not issubclass(component_class, Component):
-        raise TypeError(
-            f"{component_type!r} resolved to {component_class} which is not a subclass "
-            f"of Component"
-        )
-
-    # Instantiate the component
-    component = component_class(**config)
-
-    # Merge the overrides to the hard-coded configuration
-    child_components_config = merge_config(
-        component._child_components, child_components_config
-    )
-
-    # Create the child components
-    child_components = child_components_by_alias[path] = {}
-    for alias, child_config in child_components_config.items():
-        if child_config is None:
-            child_config = {}
-
-        if not isinstance(child_config, MutableMapping):
-            raise TypeError(
-                f"{path}: child component configuration must be either None or a dict "
-                f"(or other mutable mapping type)"
-            )
-
-        # If the type was specified only via an alias, use that as a type
-        child_config.setdefault("type", alias)
-
-        # If the type contains a forward slash, split the latter part out of it
-        if isinstance(child_config["type"], str) and "/" in child_config["type"]:
-            child_config["type"] = child_config["type"].split("/")[0]
-
-        final_path = f"{path}.{alias}" if path else alias
-
-        child_component = _init_component(
-            child_config, final_path, child_components_by_alias
-        )
-        child_components[alias] = child_component
-
-    return component
-
-
-async def _start_component(
-    component: Component,
-    path: str,
-    child_components_by_alias: dict[str, dict[str, Component]],
-) -> None:
-    # Prevent add_component() from being called beyond this point
-    component._component_started = True
-
-    # Call prepare() on the component itself
-    await component.prepare()
-
-    # Start the child components
-    if child_components := child_components_by_alias.get(path):
-        async with create_task_group() as tg:
-            for alias, child_component in child_components.items():
-                final_path = f"{path}.{alias}" if path else alias
-                tg.start_soon(
-                    _start_component,
-                    child_component,
-                    final_path,
-                    child_components_by_alias,
-                    name=f"Starting {final_path} ({qualified_name(child_component)})",
-                )
-
-    await component.start()
-
-
 @overload
 async def start_component(
     component_class: type[TComponent],
@@ -254,7 +198,6 @@ async def start_component(
         ``timeout`` seconds
     :raises TypeError: if ``component_class`` is neither a :class:`Component` subclass
         or a string
-    :return: the root component instance
 
     """
     try:
@@ -267,132 +210,414 @@ async def start_component(
     if config is None:
         config = {}
 
-    config.setdefault("type", component_class)
-    child_components_by_alias: dict[str, dict[str, Component]] = {}
-    root_component = _init_component(config, "", child_components_by_alias)
+    orchestrator = ComponentStartupOrchestrator(component_class, config)
+    return await orchestrator.start_component_tree(timeout)
 
-    with CancelScope() as startup_scope:
-        startup_watcher_scope: CancelScope | None = None
-        if timeout is not None:
-            startup_watcher_scope = await start_service_task(
-                lambda task_status: _component_startup_watcher(
-                    startup_scope,
-                    root_component,
-                    timeout,
-                    task_status=task_status,
-                ),
-                "Asphalt component startup watcher task",
+
+class ComponentStartupEvent(Event):
+    __slots__ = "component_class", "path", "status", "coro"
+
+    def __init__(
+        self,
+        component_class: type[Component],
+        path: str,
+        status: str,
+        coro: Coroutine[Any, Any, Any] | None = None,
+    ):
+        self.component_class = component_class
+        self.path = path
+        self.status = status
+        self.coro = coro
+
+
+class ComponentContextProxy(Context):
+    _parent: Context
+
+    def __init__(
+        self,
+        path: str,
+        component_class: type[Component],
+        orchestrator: ComponentStartupOrchestrator,
+    ):
+        super().__init__()
+        self.__path = path
+        self.__component_class = component_class
+        self.__orchestrator = orchestrator
+
+        # Proxy the real context, not another component proxy
+        while isinstance(self._parent, ComponentContextProxy):
+            self._parent = self._parent._parent
+
+    def __format_resource_description(
+        self, types: Any, name: str, description: str | None = None
+    ) -> str:
+        if isclass(types):
+            formatted = f"type={qualified_name(types)}"
+        else:
+            formatted_types = [qualified_name(type_) for type_ in types]
+            formatted = f"types={formatted_types}"
+
+        formatted += f", name={name!r}"
+        if description:
+            formatted += f", description={description!r}"
+
+        return formatted
+
+    def add_resource(
+        self,
+        value: T_Resource,
+        name: str = "default",
+        types: type | Sequence[type] = (),
+        *,
+        description: str | None = None,
+        teardown_callback: Callable[[], Any] | None = None,
+    ) -> None:
+        self._parent.add_resource(
+            value,
+            name,
+            types,
+            description=description,
+            teardown_callback=teardown_callback,
+        )
+        logger.debug(
+            "%s added a resource (%s)",
+            format_component_name(self.__path, capitalize=True),
+            self.__format_resource_description(types or type(value), name, description),
+        )
+
+    def add_resource_factory(
+        self,
+        factory_callback: FactoryCallback,
+        name: str = "default",
+        *,
+        types: Sequence[type] | None = None,
+        description: str | None = None,
+    ) -> None:
+        self._parent.add_resource_factory(
+            factory_callback, name, types=types, description=description
+        )
+        logger.debug(
+            "%s added a resource factory (%s)",
+            format_component_name(self.__path, capitalize=True),
+            self.__format_resource_description(
+                types or get_type_hints(factory_callback)["return"], name, description
+            ),
+        )
+
+    @overload
+    async def get_resource(
+        self,
+        type: type[T_Resource],
+        name: str = ...,
+        *,
+        optional: Literal[True],
+    ) -> T_Resource | None: ...
+
+    @overload
+    async def get_resource(
+        self,
+        type: type[T_Resource],
+        name: str = ...,
+        *,
+        optional: Literal[False],
+    ) -> T_Resource: ...
+
+    @overload
+    async def get_resource(
+        self, type: type[T_Resource], name: str = ...
+    ) -> T_Resource: ...
+
+    async def get_resource(
+        self,
+        type: type[T_Resource],
+        name: str = "default",
+        *,
+        optional: Literal[False, True] = False,
+    ) -> T_Resource | None:
+        if optional:
+            return await self._parent.get_resource(type, name, optional=True)
+
+        try:
+            return await self._parent.get_resource(type, name)
+        except ResourceNotFound:
+            logger.debug(
+                "%s is waiting for another component to provide a resource (%s)",
+                format_component_name(self.__path, capitalize=True),
+                self.__format_resource_description(type, name),
             )
 
-        await _start_component(root_component, "", child_components_by_alias)
+            # Wait until a matching resource or resource factory is available
+            signals = [ctx.resource_added for ctx in self._parent.context_chain]
+            await wait_event(
+                signals,
+                lambda event: event.resource_name == name
+                and type in event.resource_types,
+            )
+            res = await self.get_resource(type, name)
+            logger.debug(
+                "%s got the resource it was waiting for (%s)",
+                format_component_name(self.__path, capitalize=True),
+                self.__format_resource_description(type, name),
+            )
+            return res
 
-    if startup_scope.cancel_called:
-        raise TimeoutError("timeout starting component")
+    @overload
+    def get_resource_nowait(
+        self, type: type[T_Resource], name: str = ..., *, optional: Literal[True]
+    ) -> T_Resource | None: ...
 
-    # Cancel the startup timeout, if any
-    if startup_watcher_scope:
-        startup_watcher_scope.cancel()
+    @overload
+    def get_resource_nowait(
+        self, type: type[T_Resource], name: str = ..., *, optional: Literal[False]
+    ) -> T_Resource: ...
 
-    return root_component
+    @overload
+    def get_resource_nowait(
+        self, type: type[T_Resource], name: str = ...
+    ) -> T_Resource: ...
+
+    def get_resource_nowait(
+        self,
+        type: type[T_Resource],
+        name: str = "default",
+        *,
+        optional: Literal[False, True] = False,
+    ) -> T_Resource | None:
+        if optional:
+            return self._parent.get_resource_nowait(type, name, optional=True)
+
+        return self._parent.get_resource_nowait(type, name)
+
+    def get_resources(self, type: type[T_Resource]) -> Mapping[str, T_Resource]:
+        return self._parent.get_resources(type)
+
+    def add_teardown_callback(
+        self, callback: TeardownCallback, pass_exception: bool = False
+    ) -> None:
+        self._parent.add_teardown_callback(callback, pass_exception)
 
 
-async def _component_startup_watcher(
-    startup_cancel_scope: CancelScope,
-    root_component: Component,
-    start_timeout: float,
-    *,
-    task_status: TaskStatus[CancelScope],
-) -> None:
-    def get_coro_stack_summary(coro: Any) -> StackSummary:
+class ComponentStartupOrchestrator:
+    component_status_changed = Signal(ComponentStartupEvent)
+
+    _components_by_path: dict[str, Component]
+    _child_component_aliases: dict[str, set[str]]
+
+    def __init__(
+        self, root_component_class: type[Component] | str, config: Mapping[str, Any]
+    ):
+        self.root_component_class = root_component_class
+        self.config = config
+        self._components_by_path = {}
+        self._child_component_aliases = defaultdict(set)
+
+    def _init_component(self, path: str, config: MutableMapping[str, Any]) -> None:
+        if not isinstance(config, MutableMapping):
+            raise TypeError(
+                f"{path}: component configuration must be either None or a dict (or "
+                f"any other mutable mapping type)"
+            )
+
+        # Separate the child components from the config
+        child_components_config = config.pop("components", {})
+
+        # Resolve the type to a class
+        component_type = config.pop("type")
+        component_class = component_types.resolve(component_type)
+        if not isclass(component_class) or not issubclass(component_class, Component):
+            raise TypeError(
+                f"{component_type!r} resolved to {component_class} which is not a subclass "
+                f"of Component"
+            )
+
+        # Instantiate the component
+        logger.debug("Creating %s", format_component_name(path, component_class))
+        self.component_status_changed.dispatch(
+            ComponentStartupEvent(component_class, path, "creating")
+        )
+        try:
+            component = self._components_by_path[path] = component_class(**config)
+        except Exception as exc:
+            raise ComponentStartError("creating", path, component_class) from exc
+
+        logger.debug("Created %s", format_component_name(path, component_class))
+        self.component_status_changed.dispatch(
+            ComponentStartupEvent(component_class, path, "created")
+        )
+
+        # Merge the overrides to the hard-coded configuration
+        child_components_config = merge_config(
+            component._child_components, child_components_config
+        )
+        self._child_component_aliases[path] = set(child_components_config)
+
+        # Create the child components
+        for alias, child_config in child_components_config.items():
+            if child_config is None:
+                child_config = {}
+
+            # If the type was specified only via an alias, use that as a type
+            child_config.setdefault("type", alias)
+
+            # If the type contains a forward slash, split the latter part out of it
+            if isinstance(child_config["type"], str) and "/" in child_config["type"]:
+                child_config["type"] = child_config["type"].split("/")[0]
+
+            final_path = f"{path}.{alias}" if path else alias
+            self._init_component(final_path, child_config)
+
+    async def _start_component(self, component: Component, path: str) -> Component:
+        # Prevent add_component() from being called beyond this point
+        component._component_started = True
+
+        component_class = type(component)
+        async with ComponentContextProxy(path, component_class, self):
+            # Call prepare() on the component itself, if it's implemented on the component
+            # class
+            if component_class.prepare is not Component.prepare:
+                logger.debug("Calling prepare() of %s", format_component_name(path))
+                coro = component.prepare()
+                self.component_status_changed.dispatch(
+                    ComponentStartupEvent(component_class, path, "preparing", coro)
+                )
+                try:
+                    await coro
+                except Exception as exc:
+                    raise ComponentStartError(
+                        "preparing", path, component_class
+                    ) from exc
+
+                logger.debug(
+                    "Returned from prepare() of %s", format_component_name(path)
+                )
+
+            # Start the child components, if there are any
+            if child_component_aliases := self._child_component_aliases.get(path):
+                logger.debug(
+                    "Starting the child components of %s", format_component_name(path)
+                )
+                self.component_status_changed.dispatch(
+                    ComponentStartupEvent(component_class, path, "starting children")
+                )
+                async with create_task_group() as tg:
+                    for alias in child_component_aliases:
+                        final_path = f"{path}.{alias}" if path else alias
+                        child_component = self._components_by_path[final_path]
+                        tg.start_soon(
+                            self._start_component,
+                            child_component,
+                            final_path,
+                            name=(
+                                f"Starting component {final_path} "
+                                f"({qualified_name(child_component)})"
+                            ),
+                        )
+
+            # Call start() on the component itself, if it's implemented on the component
+            # class
+            if component_class.start is not Component.start:
+                logger.debug("Calling start() of %s", format_component_name(path))
+                coro = component.start()
+                self.component_status_changed.dispatch(
+                    ComponentStartupEvent(component_class, path, "starting", coro)
+                )
+                try:
+                    await coro
+                except Exception as exc:
+                    raise ComponentStartError(
+                        "starting", path, component_class
+                    ) from exc
+
+                logger.debug("Returned from start() of %s", format_component_name(path))
+
+        self.component_status_changed.dispatch(
+            ComponentStartupEvent(component_class, path, "started")
+        )
+        return component
+
+    async def start_component_tree(self, timeout: float | None) -> Component:
+        with coalesce_exceptions():
+            async with create_task_group() as tg:
+                await tg.start(self._watch_component_tree_startup, timeout)
+                self._init_component(
+                    "", {"type": self.root_component_class, **self.config}
+                )
+                return await self._start_component(self._components_by_path[""], "")
+
+    async def _watch_component_tree_startup(
+        self, timeout: float, *, task_status: TaskStatus[None]
+    ) -> None:
+        @dataclass
+        class ComponentStatus:
+            component_class: type[Component]
+            status: str
+            coro: Coroutine[Any, Any, Any] | None
+
+        component_statuses: dict[str, ComponentStatus] = {}
+        async with self.component_status_changed.stream_events(
+            max_queue_size=200
+        ) as events:
+            task_status.started()
+            with move_on_after(timeout):
+                async for event in events:
+                    if event.status == "creating":
+                        component_statuses[event.path] = ComponentStatus(
+                            event.component_class, event.status, event.coro
+                        )
+                    elif event.status == "started":
+                        del component_statuses[event.path]
+                        if not component_statuses:
+                            break
+                    else:
+                        component_statuses[event.path].status = event.status
+                        component_statuses[event.path].coro = event.coro
+
+        if component_statuses:
+            status_summary_sections: list[str] = [
+                "Timeout waiting for the component tree to start"
+            ]
+
+            status_summary: list[str] = []
+            for path, status in component_statuses.items():
+                parts = (path or "(root)").split(".")
+                indent = "  " * (len(parts) if path else 0)
+                status_summary.append(f"{indent}{parts[-1]}: {status.status}")
+
+            title = "Current status of the components still waiting to finish startup"
+            status_summary_sections.append(f"{title}\n{'-' * len(title)}")
+            status_summary_sections.append("\n".join(status_summary))
+
+            stack_summaries: list[str] = []
+            for path, status in component_statuses.items():
+                if status.coro is not None:
+                    stack_summary = self._get_coro_stack_summary(status.coro)
+                    formatted_summary = "".join(stack_summary.format())
+                    title = f"{path} ({qualified_name(status.component_class)})"
+                    stack_summaries.append(f"{title}:\n{formatted_summary.rstrip()}")
+
+            if stack_summaries:
+                title = "Stack summaries of components still waiting to start"
+                status_summary_sections.append(f"{title}\n{'-' * len(title)}")
+                status_summary_sections.extend(stack_summaries)
+
+            logger.error("%s", "\n\n".join(status_summary_sections))
+            raise TimeoutError("timeout starting component tree")
+
+    @staticmethod
+    def _get_coro_stack_summary(coro: Coroutine[Any, Any, Any]) -> StackSummary:
         import gc
 
         frames: list[FrameType] = []
-        while isinstance(coro, Coroutine):
-            while coro.__class__.__name__ == "async_generator_asend":
+        awaitable: Awaitable[Any] | None = coro
+        while isinstance(awaitable, Coroutine):
+            while awaitable.__class__.__name__ == "async_generator_asend":
                 # Hack to get past asend() objects
-                coro = gc.get_referents(coro)[0].ag_await
+                awaitable = gc.get_referents(awaitable)[0].ag_await
 
-            if frame := getattr(coro, "cr_frame", None):
+            if frame := getattr(awaitable, "cr_frame", None):
                 frames.append(frame)
 
-            coro = getattr(coro, "cr_await", None)
+            awaitable = getattr(awaitable, "cr_await", None)
 
         frame_tuples = [(f, f.f_lineno) for f in frames]
         return StackSummary.extract(frame_tuples)
-
-    current_task = get_current_task()
-    parent_task = next(
-        task_info
-        for task_info in get_running_tasks()
-        if task_info.id == current_task.parent_id
-    )
-
-    with CancelScope() as cancel_scope:
-        task_status.started(cancel_scope)
-        await sleep(start_timeout)
-
-    if cancel_scope.cancel_called:
-        return
-
-    @dataclass
-    class ComponentStatus:
-        name: str
-        alias: str | None
-        parent_task_id: int | None
-        traceback: list[str] = field(init=False, default_factory=list)
-        children: list[ComponentStatus] = field(init=False, default_factory=list)
-
-    import re
-    import textwrap
-
-    component_task_re = re.compile(r"^Starting (\S+) \((.+)\)$")
-    component_statuses: dict[int, ComponentStatus] = {}
-    for task in get_running_tasks():
-        if task.id == parent_task.id:
-            status = ComponentStatus(qualified_name(root_component), None, None)
-        elif task.name and (match := component_task_re.match(task.name)):
-            name: str
-            alias: str
-            alias, name = match.groups()
-            status = ComponentStatus(name, alias, task.parent_id)
-        else:
-            continue
-
-        status.traceback = get_coro_stack_summary(task.coro).format()
-        component_statuses[task.id] = status
-
-    root_status: ComponentStatus
-    for task_id, component_status in component_statuses.items():
-        if component_status.parent_task_id is None:
-            root_status = component_status
-        elif parent_status := component_statuses.get(component_status.parent_task_id):
-            parent_status.children.append(component_status)
-
-    def format_status(status_: ComponentStatus, level: int) -> str:
-        title = f"{status_.alias or 'root'} ({status_.name})"
-        if status_.children:
-            children_output = ""
-            for i, child in enumerate(status_.children):
-                prefix = "| " if i < (len(status_.children) - 1) else "  "
-                children_output += "+-" + textwrap.indent(
-                    format_status(child, level + 1),
-                    prefix,
-                    lambda line: line[0] in " +|",
-                )
-
-            output = title + "\n" + children_output
-        else:
-            formatted_traceback = "".join(status_.traceback)
-            if level == 0:
-                formatted_traceback = textwrap.indent(formatted_traceback, "| ")
-
-            output = title + "\n" + formatted_traceback
-
-        return output
-
-    logger.error(
-        "Timeout waiting for the root component to start\n"
-        "Components still waiting to finish startup:\n%s",
-        textwrap.indent(format_status(root_status, 0).rstrip(), "  "),
-    )
-    startup_cancel_scope.cancel()

--- a/src/asphalt/core/_exceptions.py
+++ b/src/asphalt/core/_exceptions.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from ._utils import qualified_name
+from typing import TYPE_CHECKING, Literal
+
+from ._utils import format_component_name, qualified_name
+
+if TYPE_CHECKING:
+    from ._component import Component
 
 
 class AsyncResourceError(Exception):
@@ -10,11 +15,46 @@ class AsyncResourceError(Exception):
     """
 
 
+class ComponentStartError(Exception):
+    """
+    Raised by :func:`start_component` when there's an error instantiating or starting a
+    component.
+
+    .. note:: The underlying exception can be retrieved from the ``__cause__``
+        attribute.
+
+    :ivar Literal["creating", "preparing", "starting"] phase: the phase of the component
+        initialization in which the error occurred
+    :ivar str path: the path of the component in the configuration (an empty string if
+        this is the root component)
+    :ivar type[Component] component_type: the component class
+    """
+
+    def __init__(
+        self,
+        phase: Literal["creating", "preparing", "starting"],
+        path: str,
+        component_type: type[Component],
+    ):
+        super().__init__(phase, path, component_type)
+        self.phase = phase
+        self.path = path
+        self.component_type = component_type
+
+    def __str__(self) -> str:
+        exc_msg = qualified_name(self.__cause__)
+        if exc_str := str(self.__cause__):
+            exc_msg += f": {exc_str}"
+
+        formatted_name = format_component_name(self.path, self.component_type)
+        return f"error {self.phase} {formatted_name}: {exc_msg}"
+
+
 class NoCurrentContext(Exception):
     """Raised by :func: `current_context` when there is no active context."""
 
     def __init__(self) -> None:
-        super().__init__("There is no active context")
+        super().__init__("there is no active context")
 
 
 class ResourceConflict(Exception):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
+import logging
 import sys
 from typing import Any, NoReturn
 from unittest.mock import Mock
 
 import anyio
 import pytest
-from anyio import sleep
+from anyio import Event, sleep
 from common import raises_in_exception_group
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 
 from asphalt.core import (
     CLIApplicationComponent,
     Component,
+    ComponentStartError,
     Context,
     add_resource,
+    get_resource,
     get_resource_nowait,
     run_application,
     start_component,
@@ -61,24 +64,19 @@ class TestComplexComponent:
             pytest.param("dummy", id="entrypoint"),
         ],
     )
-    async def test_add_component(self, component_type: type[Component] | str) -> None:
+    async def test_add_component(
+        self, component_type: type[Component] | str, caplog: LogCaptureFixture
+    ) -> None:
         """
         Test that add_component works with an without an entry point and that external
         configuration overriddes directly supplied configuration values.
 
         """
+        caplog.set_level(logging.DEBUG, "asphalt.core")
         components_container: dict[str, DummyComponent] = {}
 
         class ContainerComponent(Component):
             def __init__(self) -> None:
-                self.add_component(
-                    "dummy",
-                    component_type,
-                    alias="dummy",
-                    container=components_container,
-                    a=5,
-                    b=2,
-                )
                 self.add_component(
                     "dummy/alt",
                     alias="dummy/alt",
@@ -90,9 +88,19 @@ class TestComplexComponent:
         async with Context():
             await start_component(ContainerComponent)
 
-        assert len(components_container) == 2
-        assert components_container["dummy"].kwargs == {"a": 5, "b": 2}
+        assert len(components_container) == 1
         assert components_container["dummy/alt"].kwargs == {"a": 8, "b": 7}
+        assert caplog.messages == [
+            "Creating the root component (test_component.TestComplexComponent"
+            ".test_add_component.<locals>.ContainerComponent)",
+            "Created the root component (test_component.TestComplexComponent"
+            ".test_add_component.<locals>.ContainerComponent)",
+            "Creating component 'dummy/alt' (test_component.DummyComponent)",
+            "Created component 'dummy/alt' (test_component.DummyComponent)",
+            "Starting the child components of the root component",
+            "Calling start() of component 'dummy/alt'",
+            "Returned from start() of component 'dummy/alt'",
+        ]
 
     async def test_child_components_from_config(self) -> None:
         container: dict[str, Component] = {}
@@ -137,7 +145,9 @@ class TestComplexComponent:
                 self.add_component("foo", DummyComponent)
 
         async with Context():
-            with pytest.raises(RuntimeError, match="child components cannot be added"):
+            with pytest.raises(
+                ComponentStartError, match="child components cannot be added"
+            ):
                 await start_component(BadContainerComponent)
 
 
@@ -170,6 +180,7 @@ class TestCLIApplicationComponent:
                 run_application(DummyCLIComponent, backend=anyio_backend_name)
 
         assert exc.value.code == 1
+        print(str(record[0].message))
         assert len(record) == 1
         assert str(record[0].message) == "exit code out of range: 128"
 
@@ -213,7 +224,7 @@ async def test_start_component_timeout() -> None:
             await start_component(StallingComponent, timeout=0.01)
 
 
-async def test_prepare() -> None:
+async def test_prepare(caplog: LogCaptureFixture) -> None:
     class ParentComponent(Component):
         def __init__(self) -> None:
             self.add_component("child", ChildComponent)
@@ -229,6 +240,82 @@ async def test_prepare() -> None:
             foo = get_resource_nowait(str)
             add_resource(foo + "bar", "bar")
 
+    caplog.set_level(logging.DEBUG, "asphalt.core")
     async with Context():
         await start_component(ParentComponent)
         assert get_resource_nowait(str, "bar") == "foobar"
+
+    assert caplog.messages == [
+        "Creating the root component "
+        "(test_component.test_prepare.<locals>.ParentComponent)",
+        "Created the root component "
+        "(test_component.test_prepare.<locals>.ParentComponent)",
+        "Creating component 'child' "
+        "(test_component.test_prepare.<locals>.ChildComponent)",
+        "Created component 'child' "
+        "(test_component.test_prepare.<locals>.ChildComponent)",
+        "Calling prepare() of the root component",
+        "The root component added a resource (type=str, name='default')",
+        "Returned from prepare() of the root component",
+        "Starting the child components of the root component",
+        "Calling start() of component 'child'",
+        "Component 'child' added a resource (type=str, name='bar')",
+        "Returned from start() of component 'child'",
+        "Calling start() of the root component",
+        "Returned from start() of the root component",
+    ]
+
+
+async def test_wait_for_resource(caplog: LogCaptureFixture) -> None:
+    class ParentComponent(Component):
+        def __init__(self) -> None:
+            self.add_component("child1", Child1Component)
+            self.add_component("child2", Child2Component)
+
+    class Child1Component(Component):
+        async def start(self) -> None:
+            child1_ready_event.set()
+            await child2_ready_event.wait()
+            add_resource("from_child1", "special")
+
+    class Child2Component(Component):
+        async def start(self) -> None:
+            await child1_ready_event.wait()
+            child2_ready_event.set()
+            assert await get_resource(str, "special") == "from_child1"
+
+    caplog.set_level(logging.DEBUG, "asphalt.core")
+    child1_ready_event = Event()
+    child2_ready_event = Event()
+    async with Context():
+        await start_component(ParentComponent)
+
+    assert caplog.messages[:7] == [
+        "Creating the root component "
+        "(test_component.test_wait_for_resource.<locals>.ParentComponent)",
+        "Created the root component "
+        "(test_component.test_wait_for_resource.<locals>.ParentComponent)",
+        "Creating component 'child1' "
+        "(test_component.test_wait_for_resource.<locals>.Child1Component)",
+        "Created component 'child1' "
+        "(test_component.test_wait_for_resource.<locals>.Child1Component)",
+        "Creating component 'child2' "
+        "(test_component.test_wait_for_resource.<locals>.Child2Component)",
+        "Created component 'child2' "
+        "(test_component.test_wait_for_resource.<locals>.Child2Component)",
+        "Starting the child components of the root component",
+    ]
+    # Trio's nondeterministic scheduling forces us to do this
+    assert sorted(caplog.messages[7:9]) == [
+        "Calling start() of component 'child1'",
+        "Calling start() of component 'child2'",
+    ]
+    assert caplog.messages[9:] == [
+        "Component 'child2' is waiting for another component to provide a resource "
+        "(type=str, name='special')",
+        "Component 'child1' added a resource (type=str, name='special')",
+        "Returned from start() of component 'child1'",
+        "Component 'child2' got the resource it was waiting for (type=str, "
+        "name='special')",
+        "Returned from start() of component 'child2'",
+    ]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -351,10 +351,6 @@ class TestContext:
         assert exc.value.type is int
         assert exc.value.name == "foo"
 
-    async def test_get_resource_optional_wait(self, context: Context) -> None:
-        with pytest.raises(ValueError, match="doesn't make sense"):
-            await context.get_resource(int, optional=True, wait=True)
-
     async def test_start_service_task_cancel_on_exit(self) -> None:
         started = False
         finished = False

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -246,6 +246,7 @@ def test_start_timeout(caplog: LogCaptureFixture, anyio_backend_name: str) -> No
             if not self.is_leaf:
                 self.add_component("child1", StallingComponent, level=level + 1)
                 self.add_component("child2", StallingComponent, level=level + 1)
+                self.add_component("child3", Component)
 
         async def start(self) -> None:
             if self.is_leaf:


### PR DESCRIPTION
* Resources and resource factories added by components during startup are now logged (on the DEBUG level), as are components going through the various stages of their start-up.
* Removed the `wait` parameter from `get_resource()`, as this is now implicitly done during component startup, and is not useful outside of it.