### PR TITLE
Merged BoundSignal to Signal

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,7 @@ Events
 .. autoclass:: SignalQueueFull
 .. autofunction:: stream_events
 .. autofunction:: wait_event
+.. autoexception:: UnboundSignal
 
 Exceptions
 ----------

--- a/src/asphalt/core/_event.py
+++ b/src/asphalt/core/_event.py
@@ -76,7 +76,7 @@ class Signal(Generic[T_Event]):
     Declaration of a signal that can be used to dispatch events.
 
     This is a descriptor that returns itself on class level attribute access and a bound
-    version of itself on instance level access. Streaming events and dispatching
+    version of itself on instance level access. Dispatching and streaming
     events only works with these bound instances.
 
     Each signal must be assigned to a class attribute, but only once. The Signal will

--- a/src/asphalt/core/_event.py
+++ b/src/asphalt/core/_event.py
@@ -76,7 +76,7 @@ class Signal(Generic[T_Event]):
     Declaration of a signal that can be used to dispatch events.
 
     This is a descriptor that returns itself on class level attribute access and a bound
-    version of itself on instance level access. Connecting listeners and dispatching
+    version of itself on instance level access. Streaming events and dispatching
     events only works with these bound instances.
 
     Each signal must be assigned to a class attribute, but only once. The Signal will

--- a/src/asphalt/core/_exceptions.py
+++ b/src/asphalt/core/_exceptions.py
@@ -77,3 +77,13 @@ class ResourceNotFound(LookupError):
             f"no matching resource was found for type={qualified_name(self.type)} "
             f"name={self.name!r}"
         )
+
+
+class UnboundSignal(Exception):
+    """
+    Raised when attempting to dispatch or listen to events on a :class:`Signal` on
+    the class level, rather than on an instance of the class.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("attempted to use a signal that is not bound to an instance")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -11,6 +11,7 @@ from anyio.abc import TaskStatus
 from anyio.lowlevel import checkpoint
 
 from asphalt.core import Event, Signal, SignalQueueFull, stream_events, wait_event
+from asphalt.core._exceptions import UnboundSignal
 
 pytestmark = pytest.mark.anyio()
 
@@ -170,6 +171,20 @@ class TestSignal:
             next((x for x in gc.get_objects() if isinstance(x, SignalOwner)), None)
             is None
         )
+
+    def test_dispatch_unbound_signal(self) -> None:
+        with pytest.raises(
+            UnboundSignal,
+            match="attempted to use a signal that is not bound to an instance",
+        ):
+            DummySource.event_a.dispatch(DummyEvent())
+
+    async def test_wait_unbound_signal(self) -> None:
+        with pytest.raises(
+            UnboundSignal,
+            match="attempted to use a signal that is not bound to an instance",
+        ):
+            await DummySource.event_a.wait_event()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This removes a huge wart in the events API.

<!-- Thank you for your contribution! -->
## Changes

This merges the (internal) `BoundSignal` class into `Signal`, eliminating problems that stemmed from this unusual use of descriptors.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/asphalt-framework/asphalt/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
